### PR TITLE
fix: Clear DisableShaderPasses from shader fallback materials (#17)

### DIFF
--- a/Editor/MainWindow/LightingTestGUI.cs
+++ b/Editor/MainWindow/LightingTestGUI.cs
@@ -427,6 +427,11 @@ namespace lilAvatarUtils.MainWindow
             if(tag.Contains("DoubleSided")) materialFallback.SetInt("_Cull", 0);
             else                            materialFallback.SetInt("_Cull", 2);
 
+            foreach (var pass in new string[] { "Always", "ForwardBase", "ForwardAdd", "Deferred", "ShadowCaster", "MotionVectors", "Vertex", "VertexLMRGBM", "VertexLM", "Meta" })
+            {
+                materialFallback.SetShaderPassEnabled(pass, true);
+            }
+
             return materialFallback;
         }
 


### PR DESCRIPTION
materialFallback から DisableShaderPasses をクリアするコードを追加しました。

VRChatクライアントでは特定の名称のプロパティを個別にコピーする実装になっているはずです。
cf: https://creators.vrchat.com/avatars/shader-fallback-system/
特に _MainTex_ST などのリストに未記載だがコピーされていてほしいプロパティ等が、過去にVRChatクライアントのバグ修正として盛り込まれたことからも、全プロパティをコピーする実装にはなっていないことが推測できます。

そのため lilAvatarUtils では `materialFallback.CopyPropertiesFromMaterial(material);` にてプロパティを全コピーしていることから、一部の設定値 (RenderQueueなど) を戻す必要が生じることになりました。
CopyPropertiesFromMaterial を止めてプロパティを個別にコピーする実装とすればよりVRChatクライアントに挙動が近付くはずですが、全プロパティコピーに手を付けるとデグレードリスクが大きいため、今回は DisableShaderPasses を戻す処理のみ追加しています。