### PR TITLE
fix: wrong display name for sub assets

### DIFF
--- a/Editor/MainWindow/GUIUtils.cs
+++ b/Editor/MainWindow/GUIUtils.cs
@@ -163,6 +163,7 @@ namespace lilAvatarUtils.MainWindow
             GUIContent content = EditorGUIUtility.ObjectContent(obj, obj.GetType());
             content.tooltip = AssetDatabase.GetAssetPath(obj);
             if(!string.IsNullOrEmpty(content.tooltip)) content.text = Path.GetFileName(content.tooltip);
+            if(AssetDatabase.IsSubAsset(obj)) content.text = obj.name;
 
             var sizeCopy = EditorGUIUtility.GetIconSize();
             EditorGUIUtility.SetIconSize(new Vector2(rect.height-2, rect.height-2));


### PR DESCRIPTION
TexTransTool や LightLimitChangerForMA などの非破壊ツールの適用後のアバターはテクスチャの多くが 処理速度やNDMFの関係の都合で SubAssets になっています。
それらのテクスチャなどを表示すると、サブアセットなのにもかかわらず、ファイル名を表示しているために識別性が非常に悪くなっています。
![image](https://github.com/user-attachments/assets/0adbd625-246d-4610-9dc7-41a940a91fed)

なので、サブアセットだった場合にアセットの名前を表示するように修正するプルリクエストです！
![image](https://github.com/user-attachments/assets/ecb19c61-8463-43c5-bf34-f67c602551d9)
