### PR TITLE
fix: The shader name is not displayed correctly in the Shader column of the Material tab

### DIFF
--- a/Editor/MainWindow/AvatarUtils.cs
+++ b/Editor/MainWindow/AvatarUtils.cs
@@ -34,6 +34,7 @@ namespace lilAvatarUtils.MainWindow
     internal class AvatarUtilsWindow : EditorWindow
     {
         internal const string TEXT_WINDOW_NAME = "AvatarUtils";
+        internal static bool isMaterialsGUITabOpen = false;
 
         public EditorMode editorMode = EditorMode.Textures;
         public GameObject gameObject;
@@ -72,38 +73,52 @@ namespace lilAvatarUtils.MainWindow
             editorMode = (EditorMode)GUILayout.Toolbar((int)editorMode, sEditorModeList);
             if(editorMode == EditorMode.Textures)
             {
+                isMaterialsGUITabOpen = false;
+
                 texturesGUI.Draw(this);
                 return;
             }
             if(editorMode == EditorMode.Materials)
             {
+                isMaterialsGUITabOpen = true;
+
                 materialsGUI.Draw(this);
                 return;
             }
             if(editorMode == EditorMode.Animations)
             {
+                isMaterialsGUITabOpen = false;
+
                 animationClipGUI.Draw(this);
                 return;
             }
             if(editorMode == EditorMode.Renderers)
             {
+                isMaterialsGUITabOpen = false;
+
                 renderersGUI.Draw(this);
                 return;
             }
             #if LIL_VRCSDK3_AVATARS
             if(editorMode == EditorMode.PhysBones)
             {
+                isMaterialsGUITabOpen = false;
+
                 physBonesGUI.Draw(this);
                 return;
             }
             #endif
             if(editorMode == EditorMode.Lighting)
             {
+                isMaterialsGUITabOpen = false;
+
                 lightingTestGUI.Draw(this);
                 return;
             }
             if(editorMode == EditorMode.Utils)
             {
+                isMaterialsGUITabOpen = false;
+
                 if(gameObject == null) return;
                 if(GUILayout.Button("Clean up Materials"))
                 {

--- a/Editor/MainWindow/GUIUtils.cs
+++ b/Editor/MainWindow/GUIUtils.cs
@@ -161,7 +161,7 @@ namespace lilAvatarUtils.MainWindow
             else        style = EditorStyles.label;
             GUIContent content = EditorGUIUtility.ObjectContent(obj, obj.GetType());
             content.tooltip = AssetDatabase.GetAssetPath(obj);
-            if(!string.IsNullOrEmpty(content.tooltip)) content.text = Path.GetFileName(content.tooltip);
+            if(!string.IsNullOrEmpty(content.tooltip) && !AvatarUtilsWindow.isMaterialsGUITabOpen) content.text = Path.GetFileName(content.tooltip);
             if(AssetDatabase.IsSubAsset(obj)) content.text = obj.name;
 
             var sizeCopy = EditorGUIUtility.GetIconSize();


### PR DESCRIPTION
1.1.0バージョンから #8 に対応したことで生じた問題です。
lilToonの場合は比較的名前が分かりやすいのですが、Poiyomiはバージョンが違っても同じように`Poiyomi.shader`で表示されるため、使用するバージョンを確認できません。

したがって、Materialsタブだけを #8 の変更事項から除外する方式で具現しました。
できればMaterialsタブのShader部分だけを除外したいのですが、確認してみて修正していただければ幸いです。


**1.0.3**
![image](https://github.com/user-attachments/assets/419f2dbd-8323-440e-b2e0-523120eb063c)

**1.2.0**
![image](https://github.com/user-attachments/assets/c33432da-6bca-4cd7-a2a7-db0084beaffc)


