### PR TITLE
fix: fallback material may appear visually incorrect

### DIFF
--- a/Editor/MainWindow/LightingTestGUI.cs
+++ b/Editor/MainWindow/LightingTestGUI.cs
@@ -423,8 +423,14 @@ namespace jp.lilxyzw.avatarutils
             var tag = material.GetTag("VRCFallback", true);
             if(string.IsNullOrEmpty(tag) && material.shader) tag = material.shader.name.Replace("Hidden","");
 
-            var materialFallback = new Material(TagToSafetyShader(tag));
-            materialFallback.CopyPropertiesFromMaterial(material);
+            var materialFallbackCopy = new Material(TagToSafetyShader(tag));
+            materialFallbackCopy.CopyPropertiesFromMaterial(material);
+
+            // Properties copied via CopyPropertiesFromMaterial remain incomplete until the scene is saved.
+            // Creating a new material instance ensures all properties are correctly applied.
+            var materialFallback = new Material(materialFallbackCopy);
+            Object.DestroyImmediate(materialFallbackCopy);
+
             materialFallback.renderQueue = materialFallback.shader.renderQueue;
             if(tag.Contains("DoubleSided")) materialFallback.SetInt("_Cull", 0);
             else                            materialFallback.SetInt("_Cull", 2);

--- a/Editor/MainWindow/LightingTestGUI.cs
+++ b/Editor/MainWindow/LightingTestGUI.cs
@@ -423,8 +423,7 @@ namespace jp.lilxyzw.avatarutils
             var tag = material.GetTag("VRCFallback", true);
             if(string.IsNullOrEmpty(tag) && material.shader) tag = material.shader.name.Replace("Hidden","");
 
-            var safetyShader = TagToSafetyShader(tag);
-            var materialFallback = new Material(safetyShader);
+            var materialFallback = new Material(TagToSafetyShader(tag));
             materialFallback.CopyPropertiesFromMaterial(material);
             materialFallback.renderQueue = materialFallback.shader.renderQueue;
             if(tag.Contains("DoubleSided")) materialFallback.SetInt("_Cull", 0);
@@ -434,11 +433,6 @@ namespace jp.lilxyzw.avatarutils
             {
                 materialFallback.SetShaderPassEnabled(pass, true);
             }
-
-            // Workaround: After calling CopyPropertiesFromMaterial(), the material may appear visually incorrect.
-            // Reassigning material.shader (even to the same) forces Unity to refresh the internal state.
-            // https://discussions.unity.com/t/copypropertiesfrommaterial-corrupts-material-in-play-mode/693156/4
-            materialFallback.shader = safetyShader;
 
             return materialFallback;
         }

--- a/Editor/MainWindow/LightingTestGUI.cs
+++ b/Editor/MainWindow/LightingTestGUI.cs
@@ -423,7 +423,8 @@ namespace jp.lilxyzw.avatarutils
             var tag = material.GetTag("VRCFallback", true);
             if(string.IsNullOrEmpty(tag) && material.shader) tag = material.shader.name.Replace("Hidden","");
 
-            var materialFallback = new Material(TagToSafetyShader(tag));
+            var safetyShader = TagToSafetyShader(tag);
+            var materialFallback = new Material(safetyShader);
             materialFallback.CopyPropertiesFromMaterial(material);
             materialFallback.renderQueue = materialFallback.shader.renderQueue;
             if(tag.Contains("DoubleSided")) materialFallback.SetInt("_Cull", 0);
@@ -433,6 +434,11 @@ namespace jp.lilxyzw.avatarutils
             {
                 materialFallback.SetShaderPassEnabled(pass, true);
             }
+
+            // Workaround: After calling CopyPropertiesFromMaterial(), the material may appear visually incorrect.
+            // Reassigning material.shader (even to the same) forces Unity to refresh the internal state.
+            // https://discussions.unity.com/t/copypropertiesfrommaterial-corrupts-material-in-play-mode/693156/4
+            materialFallback.shader = safetyShader;
 
             return materialFallback;
         }


### PR DESCRIPTION
Resolves #33 です。

[似たような事例](https://discussions.unity.com/t/copypropertiesfrommaterial-corrupts-material-in-play-mode/693156/4)と同様に Material.shader の再設定で解決しました。